### PR TITLE
Add sign-out and conditional home buttons

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,8 @@ import './globals.css';
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import Image from 'next/image';
+import { Providers } from './providers';
+import NavBar from '../components/NavBar';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -19,53 +21,16 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <nav className="border-b border-border">
-          <div className="container flex items-center justify-between py-4">
-            <a href="/" className="flex items-center gap-2 hover:opacity-90 transition-opacity">
-              <Image
-                src="/images/logo.png"
-                alt="SpotPhotos Logo"
-                width={40}
-                height={40}
-                className="w-auto h-8"
-              />
-              <div className="flex flex-col">
-                <span className="text-xl font-bold">SpotPhotos</span>
-                <span className="text-xs text-muted">Capture. Spot. Smile.</span>
-              </div>
-            </a>
-            <div className="flex items-center gap-8">
-              <a 
-                href="/events" 
-                className="text-secondary hover:text-primary relative py-2 transition-colors duration-200 after:content-[''] after:absolute after:left-0 after:bottom-0 after:h-0.5 after:w-0 after:bg-primary after:transition-all after:duration-300 hover:after:w-full"
-              >
-                Events
-              </a>
-              <a 
-                href="/photographer" 
-                className="text-secondary hover:text-primary relative py-2 transition-colors duration-200 after:content-[''] after:absolute after:left-0 after:bottom-0 after:h-0.5 after:w-0 after:bg-primary after:transition-all after:duration-300 hover:after:w-full"
-              >
-                Photographer
-              </a>
-              <a 
-                href="/spot-check" 
-                className="text-secondary hover:text-primary relative py-2 transition-colors duration-200 after:content-[''] after:absolute after:left-0 after:bottom-0 after:h-0.5 after:w-0 after:bg-primary after:transition-all after:duration-300 hover:after:w-full"
-              >
-                Spot Check
-              </a>
+        <Providers>
+          <NavBar />
+          <main className="min-h-screen py-8">
+            <div className="container animate-fade-in">
+              {children}
             </div>
-          </div>
-        </nav>
-
-        <main className="min-h-screen py-8">
-          <div className="container animate-fade-in">
-            {children}
-          </div>
-        </main>
-
-        <footer className="border-t border-border bg-card">
-          <div className="container py-8">
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+          </main>
+          <footer className="border-t border-border bg-card">
+            <div className="container py-8">
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
               <div className="flex items-center gap-4">
                 <Image
                   src="/images/logo.png"
@@ -118,7 +83,8 @@ export default function RootLayout({
             </div>
           </div>
         </footer>
+        </Providers>
       </body>
     </html>
   );
-} 
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import Link from 'next/link';
+import { useSession } from 'next-auth/react';
 
 interface Event {
   id: string;
@@ -10,6 +11,7 @@ interface Event {
 }
 
 export default function Home() {
+  const { data: session } = useSession();
   const [events, setEvents] = useState<Event[]>([]);
   const [newEvent, setNewEvent] = useState<Event>({
     id: '',
@@ -74,18 +76,22 @@ export default function Home() {
           Make your events more memorable.
         </p>
         <div className="flex gap-4 justify-center">
-          <Link 
-            href="/events" 
-            className="button button-primary"
-          >
-            Create Event
-          </Link>
-          <Link 
-            href="/spot-check" 
-            className="button button-secondary"
-          >
-            Find Your Photos
-          </Link>
+          {session && (
+            <>
+              <Link
+                href="/events"
+                className="button button-primary"
+              >
+                Create Event
+              </Link>
+              <Link
+                href="/spot-check"
+                className="button button-secondary"
+              >
+                Find Your Photos
+              </Link>
+            </>
+          )}
         </div>
       </section>
 

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { signOut, useSession } from 'next-auth/react';
+import React from 'react';
+
+export default function NavBar() {
+  const { data: session } = useSession();
+
+  return (
+    <nav className="border-b border-border">
+      <div className="container flex items-center justify-between py-4">
+        <a href="/" className="flex items-center gap-2 hover:opacity-90 transition-opacity">
+          <Image
+            src="/images/logo.png"
+            alt="SpotPhotos Logo"
+            width={40}
+            height={40}
+            className="w-auto h-8"
+          />
+          <div className="flex flex-col">
+            <span className="text-xl font-bold">SpotPhotos</span>
+            <span className="text-xs text-muted">Capture. Spot. Smile.</span>
+          </div>
+        </a>
+        <div className="flex items-center gap-8">
+          <a
+            href="/events"
+            className="text-secondary hover:text-primary relative py-2 transition-colors duration-200 after:content-[''] after:absolute after:left-0 after:bottom-0 after:h-0.5 after:w-0 after:bg-primary after:transition-all after:duration-300 hover:after:w-full"
+          >
+            Events
+          </a>
+          <a
+            href="/photographer"
+            className="text-secondary hover:text-primary relative py-2 transition-colors duration-200 after:content-[''] after:absolute after:left-0 after:bottom-0 after:h-0.5 after:w-0 after:bg-primary after:transition-all after:duration-300 hover:after:w-full"
+          >
+            Photographer
+          </a>
+          <a
+            href="/spot-check"
+            className="text-secondary hover:text-primary relative py-2 transition-colors duration-200 after:content-[''] after:absolute after:left-0 after:bottom-0 after:h-0.5 after:w-0 after:bg-primary after:transition-all after:duration-300 hover:after:w-full"
+          >
+            Spot Check
+          </a>
+          {session ? (
+            <button
+              onClick={() => signOut({ callbackUrl: '/' })}
+              className="text-secondary hover:text-primary relative py-2 transition-colors duration-200"
+            >
+              Sign Out
+            </button>
+          ) : (
+            <a
+              href="/auth/signin"
+              className="text-secondary hover:text-primary relative py-2 transition-colors duration-200"
+            >
+              Sign In
+            </a>
+          )}
+        </div>
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- create a `NavBar` component with sign-in and sign-out logic
- wrap the app in `Providers` and use the new navigation
- hide "Create Event" and "Find Your Photos" on the home page until logged in

## Testing
- `npm install`
- `npm run lint` *(fails: asks for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6840cbe8189c833092f1b87a899bb15f